### PR TITLE
fix yield request bug

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -196,7 +196,7 @@ OAuth.prototype.getAccessToken = function * (code) {
     dataType: 'json'
   };
 
-  var data = this.request(url, args);
+  var data = yield this.request(url, args);
 
   return yield this.processToken(data);
 };
@@ -237,7 +237,7 @@ OAuth.prototype.refreshAccessToken = function * (refreshToken) {
     dataType: 'json'
   };
 
-  var data = this.request(url, args);
+  var data = yield this.request(url, args);
 
   return yield this.processToken(data);
 };


### PR DESCRIPTION
没有使用 `yield` 时，无法真正调用 `this.request` 函数。